### PR TITLE
Create initial components from designs

### DIFF
--- a/components/Badge.js
+++ b/components/Badge.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html` <div>badge</div> `;

--- a/components/Button.js
+++ b/components/Button.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html` <button>button</button> `;

--- a/components/Card.js
+++ b/components/Card.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html`<div>card</div>`;

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -1,0 +1,7 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html`
+  <code>
+    <pre>editor</pre>
+  </code>
+`;

--- a/components/Example.js
+++ b/components/Example.js
@@ -1,0 +1,13 @@
+import { html } from 'https://unpkg.com/rplus';
+
+import Title from './Title.js';
+import Text from './Text.js';
+import Editor from './Editor.js';
+
+export default () => html`
+  <section>
+    <${Title} />
+    <${Text} />
+    <${Editor} />
+  </section>
+`;

--- a/components/Features.js
+++ b/components/Features.js
@@ -1,0 +1,11 @@
+import { html, css } from 'https://unpkg.com/rplus';
+
+import Card from './Card.js';
+
+export default () => html`
+  <section>
+    <${Card} />
+    <${Card} />
+    <${Card} />
+  </section>
+`;

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,0 +1,16 @@
+import { html } from 'https://unpkg.com/rplus';
+
+import Logo from './Logo.js';
+import Link from './Link.js';
+import Text from './Text.js';
+
+export default () => html`
+  <section>
+    <${Logo} />
+    <div>
+      <${Link} />
+      <${Link} />
+    </div>
+    <${Text} />
+  </section>
+`;

--- a/components/Form.js
+++ b/components/Form.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html`<form>form</form>`;

--- a/components/Guide.js
+++ b/components/Guide.js
@@ -1,0 +1,19 @@
+import { html, css } from 'https://unpkg.com/rplus';
+
+import Title from './Title.js';
+import Text from './Text.js';
+import Button from './Button.js';
+import Link from './Link.js';
+
+export default () => html`
+  <section>
+    <${Title} />
+    <${Text} />
+    <${Button} />
+    <div>
+      <${Link} />
+      <${Link} />
+      <${Link} />
+    </div>
+  </section>
+`;

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,17 @@
+import { html } from 'https://unpkg.com/rplus';
+
+import Badge from './Badge.js';
+import Title from './Title.js';
+import Text from './Text.js';
+import Form from './Form.js';
+import Nav from './Nav.js';
+
+export default () => html`
+  <header>
+    <${Badge} />
+    <${Title} />
+    <${Text} />
+    <${Form} />
+    <${Nav} />
+  </header>
+`;

--- a/components/Link.js
+++ b/components/Link.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html` <a href="#"> link</a> `;

--- a/components/Logo.js
+++ b/components/Logo.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html`<div>F</div>`;

--- a/components/Media.js
+++ b/components/Media.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html`<div>media</div>`;

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html` <nav>nav</nav> `;

--- a/components/Products.js
+++ b/components/Products.js
@@ -1,0 +1,16 @@
+import { html, css } from 'https://unpkg.com/rplus';
+
+import Title from './Title.js';
+import Media from './Media.js';
+
+export default () => html`
+  <section>
+    <${Title} />
+    <div>
+      <${Media} />
+      <${Media} />
+      <${Media} />
+      <${Media} />
+    </div>
+  </section>
+`;

--- a/components/Ribbon.js
+++ b/components/Ribbon.js
@@ -1,0 +1,9 @@
+import { html } from 'https://unpkg.com/rplus';
+
+import Logo from './Logo.js';
+
+export default () => html`
+  <div>
+    <${Logo} />
+  </div>
+`;

--- a/components/Text.js
+++ b/components/Text.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html` <p>text</p> `;

--- a/components/Title.js
+++ b/components/Title.js
@@ -1,0 +1,3 @@
+import { html } from 'https://unpkg.com/rplus';
+
+export default () => html` <h1>title</h1> `;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Formidable OSS Template</title>
+    <script src="./index.js" type="module" defer></script>
+  </head>
+  <body></body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,23 @@
+import { react, html } from 'https://unpkg.com/rplus';
+
+import Header from './components/Header.js';
+import Ribbon from './components/Ribbon.js';
+import Features from './components/Features.js';
+import Example from './components/Example.js';
+import Guide from './components/Guide.js';
+import Products from './components/Products.js';
+import Footer from './components/Footer.js';
+
+const Page = () => {
+  return html`
+    <${Ribbon} />
+    <${Header} />
+    <${Features} />
+    <${Example} />
+    <${Guide} />
+    <${Products} />
+    <${Footer} />
+  `;
+};
+
+react.render(html`<${Page} />`, document.body);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "formidable-oss-landers",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "npx servor --browse --reload --editor"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FormidableLabs/formidable-oss-landers.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/FormidableLabs/formidable-oss-landers/issues"
+  },
+  "homepage": "https://github.com/FormidableLabs/formidable-oss-landers#readme"
+}


### PR DESCRIPTION
This is a really quick setup mapping the components in the design document to react components. There is no build required here, it is essentially just a collection of static files that import each other in a reasonable order at runtime.

My plan going forward here would be something like:

- Populate the components with appropriate content for one product
- Style each of the components on the page with respect to some base theme
- Make the content configureable (formulate types/schema) and inject via context or props
- Generate a content scheme and theme for a second product and apply it to the template 🤞 

By this point we should know if we have something that is workable. Presuming it is, we could proceed to iterate and optimise.. bringing in more tools as and when we think they are necessary!