### PR TITLE
Cleanup `/docs` Page Layout

### DIFF
--- a/docs/src/components/Header.jsx
+++ b/docs/src/components/Header.jsx
@@ -5,7 +5,7 @@ import FormidableTextLogo from "../assets/formidableTextLogo";
 
 const HeaderContainer = styled.header`
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   background: ${({ theme }) => theme.colors.white};
   box-shadow: ${({ theme }) => theme.boxShadows.header};
   height: ${({ theme }) => theme.layout.headerHeight};

--- a/docs/src/components/Header.jsx
+++ b/docs/src/components/Header.jsx
@@ -11,6 +11,8 @@ const HeaderContainer = styled.header`
   height: ${({ theme }) => theme.layout.headerHeight};
   padding-left: ${({ theme }) => theme.spacing(2)};
   padding-right: ${({ theme }) => theme.spacing(2)};
+  position: fixed;
+  width: calc(100% - ${({ theme }) => theme.layout.sidebarWidth});
 
   ${(props) => props.theme.media.desktop`
     padding-left: ${({ theme }) => theme.spacing(7.5)};

--- a/docs/src/pages/docs.jsx
+++ b/docs/src/pages/docs.jsx
@@ -20,6 +20,17 @@ const ContentContainer = styled.div`
 
 const DocsPageContainer = styled.div`
   display: flex;
+  min-height: 100%;
+`;
+
+const DocContainer = styled.div`
+  padding: ${({ theme }) => theme.spacing(2)};
+  margin-top: ${({ theme }) => theme.layout.headerHeight};
+
+  ${(props) => props.theme.media.desktop`
+    padding: ${({ theme }) => theme.spacing(7.5)};
+    margin-top: ${({ theme }) => theme.layout.headerHeight};
+  `}
 `;
 
 export default function Docs() {
@@ -33,7 +44,9 @@ export default function Docs() {
           <Sidebar navLinks={pages} projectName={projectName} />
           <ContentContainer>
             <Header title={projectName} />
-            <Doc />
+            <DocContainer>
+              <Doc />
+            </DocContainer>
           </ContentContainer>
         </DocsPageContainer>
       </DocsPageTemplate>

--- a/docs/src/pages/docs.jsx
+++ b/docs/src/pages/docs.jsx
@@ -15,7 +15,7 @@ import config from "../renature-config";
 const renatureTheme = createTheme({ colors: config.colors, type: "dark" });
 
 const ContentContainer = styled.div`
-  width: 100%;
+  max-width: ${({ theme }) => theme.layout.maxWidth};
 `;
 
 const DocsPageContainer = styled.div`


### PR DESCRIPTION
hello friends ☺️ 

this PR makes a few quick but impactful adjustments to the layout of the `/docs` page!
changes include:
⚡ fixing the position of the header
⚡ making the content on the docs page always take up the full height of the page, so that the footer lays nicely at the bottom
⚡ giving the content some room to breathe!

<img width="1265" alt="Screen Shot 2020-12-03 at 3 14 55 PM" src="https://user-images.githubusercontent.com/24626685/101082978-513a7580-357a-11eb-9d3b-fca8d0d7465e.png">
