### PR TITLE
Fix Sidebar Positioning

### DIFF
--- a/src/components/DocsPageTemplate.jsx
+++ b/src/components/DocsPageTemplate.jsx
@@ -26,6 +26,7 @@ const DocsPageContainer = styled.div`
 const DocContainer = styled.div`
   padding: ${({ theme }) => theme.spacing(2)};
   margin-top: ${({ theme }) => theme.layout.headerHeight};
+  max-width: ${({ theme }) => theme.layout.maxWidth};
 
   ${(props) => props.theme.media.desktop`
     padding: ${({ theme }) => theme.spacing(7.5)};

--- a/src/components/DocsPageTemplate.jsx
+++ b/src/components/DocsPageTemplate.jsx
@@ -12,12 +12,15 @@ const Wrapper = styled.main`
 `;
 
 const ContentContainer = styled.div`
-  max-width: ${({ theme }) => theme.layout.maxWidth};
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-left: ${({ theme }) => theme.layout.sidebarWidth};
 `;
 
 const DocsPageContainer = styled.div`
   display: flex;
-  min-height: 100%;
+  height: 100vh;
 `;
 
 const DocContainer = styled.div`
@@ -40,9 +43,9 @@ function DocsPageTemplate({ projectName, doc, toc, pages }) {
           <DocContainer>
             <Doc doc={doc} toc={toc} />
           </DocContainer>
+          <Footer />
         </ContentContainer>
       </DocsPageContainer>
-      <Footer />
     </Wrapper>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -12,6 +12,7 @@ const Wrapper = styled(Section).attrs({ padding: 10 })`
   background-color: ${(props) => props.theme.colors.darkerNeutral};
   color: ${(props) => props.theme.colors.white};
   text-align: left;
+  width: calc(100vw - ${({ theme }) => theme.layout.sidebarWidth});
 
   ${(props) => props.theme.media.desktop`
     height: ${(props) => props.theme.layout.footerHeight};

--- a/src/components/docs/Sidebar.jsx
+++ b/src/components/docs/Sidebar.jsx
@@ -8,18 +8,17 @@ const SidebarContainer = styled.aside`
   display: flex;
   flex-shrink: 0;
   width: ${({ theme }) => theme.layout.sidebarWidth};
-  min-height: 500px;
+  min-height: 100vh;
+  position: fixed;
   background: ${({ theme }) => theme.colors.darkerPrimary};
 `;
 
 const LighterStripe = styled.div`
-  height: 100%;
   width: 12px;
   background: ${({ theme }) => theme.colors.primary};
 `;
 
 const LightStripe = styled.div`
-  height: 100%;
   width: 12px;
   background: ${({ theme }) => theme.colors.darkPrimary};
 `;


### PR DESCRIPTION
hello & happy monday! ✨ 

this PR accomplishes fixing the sidebar to positioning on the `/docs` page. @boygirl and I discussed how to implement this last week and decided to move the footer to the content section of the page (so there won't be a conflict if there are several sidebar items). this PR handles that as well 🙃 

<img width="1568" alt="Screen Shot 2020-12-07 at 11 48 24 AM" src="https://user-images.githubusercontent.com/24626685/101379324-230eab80-3882-11eb-9496-253f4d0a4488.png">
<img width="1568" alt="Screen Shot 2020-12-07 at 11 48 27 AM" src="https://user-images.githubusercontent.com/24626685/101379327-23a74200-3882-11eb-838c-f49b02637cb0.png">


