### PR TITLE
Hide Sidebar on Narrow Screens

### DIFF
--- a/src/components/DocsPageTemplate.jsx
+++ b/src/components/DocsPageTemplate.jsx
@@ -15,7 +15,11 @@ const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-left: ${({ theme }) => theme.layout.sidebarWidth};
+  padding-left: 24px;
+
+  ${(props) => props.theme.media.desktop`
+    padding-left: ${({ theme }) => theme.layout.sidebarWidth};
+  `}
 `;
 
 const DocsPageContainer = styled.div`

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -12,9 +12,10 @@ const Wrapper = styled(Section).attrs({ padding: 10 })`
   background-color: ${(props) => props.theme.colors.darkerNeutral};
   color: ${(props) => props.theme.colors.white};
   text-align: left;
-  width: calc(100vw - ${({ theme }) => theme.layout.sidebarWidth});
+  width: 100%;
 
   ${(props) => props.theme.media.desktop`
+    width: calc(100vw - ${({ theme }) => theme.layout.sidebarWidth});
     height: ${(props) => props.theme.layout.footerHeight};
   `}
 

--- a/src/components/docs/Header.jsx
+++ b/src/components/docs/Header.jsx
@@ -10,11 +10,12 @@ const HeaderContainer = styled.header`
   box-shadow: ${({ theme }) => theme.boxShadows.header};
   height: ${({ theme }) => theme.layout.headerHeight};
   padding-left: ${({ theme }) => theme.spacing(2)};
-  padding-right: ${({ theme }) => theme.spacing(2)};
+  padding-right: ${({ theme }) => theme.spacing(10)};
   position: fixed;
-  width: calc(100% - ${({ theme }) => theme.layout.sidebarWidth});
+  width: 100%;
 
   ${(props) => props.theme.media.desktop`
+    width: calc(100% - ${({ theme }) => theme.layout.sidebarWidth});
     padding-left: ${({ theme }) => theme.spacing(7.5)};
     padding-right: ${({ theme }) => theme.spacing(7.5)};
   `}

--- a/src/components/docs/Sidebar.jsx
+++ b/src/components/docs/Sidebar.jsx
@@ -8,9 +8,8 @@ const SidebarContainer = styled.aside`
   display: flex;
   flex-shrink: 0;
   width: ${({ theme }) => theme.layout.sidebarWidth};
-  min-height: 100vh;
+  min-height: 100%;
   position: fixed;
-  background: ${({ theme }) => theme.colors.darkerPrimary};
 `;
 
 const LighterStripe = styled.div`
@@ -24,11 +23,16 @@ const LightStripe = styled.div`
 `;
 
 const SidebarContent = styled.div`
-  display: flex;
+  display: none;
   flex-direction: column;
   align-items: center;
   padding: ${({ theme }) => theme.spacing(3)} 0;
   width: 100%;
+  background: ${({ theme }) => theme.colors.darkerPrimary};
+
+  ${(props) => props.theme.media.desktop`
+    display: flex;
+  `}
 `;
 
 const BadgeWrapper = styled.div`


### PR DESCRIPTION
woohoo, almost to wednesday 🤠 🏇 

this PR hides the sidebar on smaller screens. next, I'll work on adding a way for users to open it over the content.
I wanted to separate out this work specifically because I've never worked on anything mobile-related before! any feedback is so appreciated!
one thing I noticed is that when we get into narrower screens, somewhere between tablet and mobile size, the height of the sidebar stripes causes the page to be longer than necessary. any thoughts on this?
**desktop:**
<img width="825" alt="Screen Shot 2020-12-08 at 3 23 06 PM" src="https://user-images.githubusercontent.com/24626685/101537531-a5be6600-3969-11eb-8b0a-19b4c902eede.png">
**tablet:**
<img width="640" alt="Screen Shot 2020-12-08 at 3 23 14 PM" src="https://user-images.githubusercontent.com/24626685/101537532-a656fc80-3969-11eb-8e65-10bc06b83907.png">
**mobile:**
<img width="341" alt="Screen Shot 2020-12-08 at 3 23 37 PM" src="https://user-images.githubusercontent.com/24626685/101537533-a656fc80-3969-11eb-85fc-3ee9cf9695ed.png">


