### PR TITLE
Collapsible Sidebar on Narrower Screens

### DIFF
--- a/src/assets/BurgerIcon.jsx
+++ b/src/assets/BurgerIcon.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const BurgerIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M22 18v2H2v-2h20zm0-7v2H2v-2h20zm0-7v2H2V4h20z"
+      fill="#000"
+      fillRule="nonzero"
+    />
+  </svg>
+);
+
+export default BurgerIcon;

--- a/src/components/DocsPageTemplate.jsx
+++ b/src/components/DocsPageTemplate.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { arrayOf, string, number, shape } from "prop-types";
 import styled from "styled-components";
 import Footer from "./Footer";
@@ -42,15 +42,37 @@ const DocContainer = styled.div`
 
 function DocsPageTemplate({ projectName, doc, toc, pages }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const ref = useRef();
+
+  const handleOutsideClick = (e) => {
+    if (
+      ref.current &&
+      !ref.current.contains(e.target) &&
+      sidebarOpen === true
+    ) {
+      setSidebarOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("click", handleOutsideClick);
+
+    return () => {
+      document.removeEventListener("click", handleOutsideClick);
+    };
+  });
+
   return (
     <Wrapper>
       <DocsPageContainer>
-        <Sidebar
-          navLinks={pages}
-          projectName={projectName}
-          sidebarOpen={sidebarOpen}
-          onCloseClick={() => setSidebarOpen(false)}
-        />
+        <div ref={ref}>
+          <Sidebar
+            navLinks={pages}
+            projectName={projectName}
+            sidebarOpen={sidebarOpen}
+            onCloseClick={() => setSidebarOpen(false)}
+          />
+        </div>
         <ContentContainer>
           <Header
             title={projectName}

--- a/src/components/DocsPageTemplate.jsx
+++ b/src/components/DocsPageTemplate.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { arrayOf, string, number, shape } from "prop-types";
 import styled from "styled-components";
 import Footer from "./Footer";
@@ -16,6 +16,7 @@ const ContentContainer = styled.div`
   flex-direction: column;
   justify-content: space-between;
   padding-left: 24px;
+  width: 100%;
 
   ${(props) => props.theme.media.desktop`
     padding-left: ${({ theme }) => theme.layout.sidebarWidth};
@@ -30,6 +31,7 @@ const DocsPageContainer = styled.div`
 const DocContainer = styled.div`
   padding: ${({ theme }) => theme.spacing(2)};
   margin-top: ${({ theme }) => theme.layout.headerHeight};
+  z-index: ${({ sidebarOpen }) => (sidebarOpen ? "-1" : "1")};
   max-width: ${({ theme }) => theme.layout.maxWidth};
 
   ${(props) => props.theme.media.desktop`
@@ -39,13 +41,23 @@ const DocContainer = styled.div`
 `;
 
 function DocsPageTemplate({ projectName, doc, toc, pages }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   return (
     <Wrapper>
       <DocsPageContainer>
-        <Sidebar navLinks={pages} projectName={projectName} />
+        <Sidebar
+          navLinks={pages}
+          projectName={projectName}
+          sidebarOpen={sidebarOpen}
+          onCloseClick={() => setSidebarOpen(false)}
+        />
         <ContentContainer>
-          <Header title={projectName} />
-          <DocContainer>
+          <Header
+            title={projectName}
+            sidebarOpen={sidebarOpen}
+            onMenuClick={() => setSidebarOpen(true)}
+          />
+          <DocContainer sidebarOpen={sidebarOpen}>
             <Doc doc={doc} toc={toc} />
           </DocContainer>
           <Footer />

--- a/src/components/docs/Header.jsx
+++ b/src/components/docs/Header.jsx
@@ -38,7 +38,7 @@ const Title = styled.h1`
 `;
 
 const FormidableLogoWrapper = styled.div`
-  height: 1.6rem;
+  width: 9rem;
   display: none;
 
   ${(props) => props.theme.media.tablet`
@@ -53,6 +53,7 @@ const LeftContainer = styled.div`
 
 const MenuButton = styled.button`
   margin-right: 15px;
+  width: 1.5rem;
 
   ${(props) => props.theme.media.desktop`
     display: none;

--- a/src/components/docs/Header.jsx
+++ b/src/components/docs/Header.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import FormidableTextLogo from "../../assets/FormidableTextLogo";
+import BurgerIcon from "../../assets/BurgerIcon";
 
 const HeaderContainer = styled.header`
   display: flex;
@@ -13,6 +14,7 @@ const HeaderContainer = styled.header`
   padding-right: ${({ theme }) => theme.spacing(10)};
   position: fixed;
   width: 100%;
+  z-index: ${({ sidebarOpen }) => (sidebarOpen ? "-1" : "2")};
 
   ${(props) => props.theme.media.desktop`
     width: calc(100% - ${({ theme }) => theme.layout.sidebarWidth});
@@ -44,11 +46,29 @@ const FormidableLogoWrapper = styled.div`
   `}
 `;
 
-const Header = ({ title }) => {
+const LeftContainer = styled.div`
+  display: flex;
+  align-items: baseline;
+`;
+
+const MenuButton = styled.button`
+  margin-right: 15px;
+
+  ${(props) => props.theme.media.desktop`
+    display: none;
+  `}
+`;
+
+const Header = ({ title, sidebarOpen, onMenuClick }) => {
   return (
-    <HeaderContainer>
+    <HeaderContainer sidebarOpen={sidebarOpen}>
       <InnerContainer>
-        <Title>{title}</Title>
+        <LeftContainer>
+          <MenuButton onClick={onMenuClick}>
+            <BurgerIcon />
+          </MenuButton>
+          <Title>{title}</Title>
+        </LeftContainer>
         <FormidableLogoWrapper>
           <FormidableTextLogo />
         </FormidableLogoWrapper>
@@ -59,6 +79,8 @@ const Header = ({ title }) => {
 
 Header.propTypes = {
   title: PropTypes.string.isRequired,
+  sidebarOpen: PropTypes.bool.isRequired,
+  onMenuClick: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/src/components/docs/Sidebar.jsx
+++ b/src/components/docs/Sidebar.jsx
@@ -23,7 +23,8 @@ const LightStripe = styled.div`
 `;
 
 const SidebarContent = styled.div`
-  display: none;
+  display: ${({ sidebarOpen }) => (sidebarOpen ? "flex" : "none")};
+  z-index: ${({ sidebarOpen }) => (sidebarOpen ? "1" : "0")};
   flex-direction: column;
   align-items: center;
   padding: ${({ theme }) => theme.spacing(3)} 0;
@@ -56,13 +57,26 @@ const ListItemLink = styled(NavLink)`
   padding: 0 ${({ theme }) => theme.spacing(2.5)};
 `;
 
-const Sidebar = ({ navLinks, projectName }) => {
+const CloseButton = styled.button`
+  font-size: 2.2rem;
+  position: absolute;
+  right: 10px;
+  top: calc(10px - 0.2rem);
+  color: white;
+
+  ${(props) => props.theme.media.desktop`
+    display: none;
+  `}
+`;
+
+const Sidebar = ({ navLinks, projectName, sidebarOpen, onCloseClick }) => {
   console.log(navLinks);
   return (
     <SidebarContainer>
       <LighterStripe />
       <LightStripe />
-      <SidebarContent>
+      <SidebarContent sidebarOpen={sidebarOpen}>
+        <CloseButton onClick={onCloseClick}>&times;</CloseButton>
         <BadgeWrapper>
           <FeaturedBadge name={projectName} />
         </BadgeWrapper>
@@ -88,6 +102,8 @@ Sidebar.propTypes = {
     })
   ).isRequired,
   projectName: PropTypes.string.isRequired,
+  sidebarOpen: PropTypes.bool.isRequired,
+  onCloseClick: PropTypes.func.isRequired,
 };
 
 export default Sidebar;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -46,7 +46,7 @@ const layout = {
   maxWidth: "80rem",
   headerHeight: "3.6rem",
   footerHeight: "18.6rem",
-  sidebarWidth: "14.6rem",
+  sidebarWidth: "15rem",
 };
 
 export const createTheme = (options = {}) => {

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -46,7 +46,7 @@ const layout = {
   maxWidth: "80rem",
   headerHeight: "3.6rem",
   footerHeight: "18.6rem",
-  sidebarWidth: "15rem",
+  sidebarWidth: "15.2rem",
 };
 
 export const createTheme = (options = {}) => {

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -46,7 +46,7 @@ const layout = {
   maxWidth: "80rem",
   headerHeight: "3.6rem",
   footerHeight: "18.6rem",
-  sidebarWidth: "15.2rem",
+  sidebarWidth: "14.6rem",
 };
 
 export const createTheme = (options = {}) => {


### PR DESCRIPTION
hola amigos! 🇲🇽 we are making progress!

this PR: 
- fixes the SVG sizing issue [we were noticing in my last PR](https://github.com/FormidableLabs/formidable-oss-landers/pull/21#issuecomment-741049694)
- makes the sidebar collapsible on narrower screens!

**closed:**
<img width="1030" alt="Screen Shot 2020-12-09 at 3 26 20 PM" src="https://user-images.githubusercontent.com/24626685/101683469-f5b52f80-3a32-11eb-90f5-ade29c18c94f.png">
**open:**
<img width="1030" alt="Screen Shot 2020-12-09 at 3 26 25 PM" src="https://user-images.githubusercontent.com/24626685/101683482-f8b02000-3a32-11eb-9116-a4b9adcc387a.png">
