### PR TITLE
Getting things back up to speed :)

### DIFF
--- a/docs/src/renature-config.jsx
+++ b/docs/src/renature-config.jsx
@@ -1,6 +1,6 @@
 /* Example config for Renature OSS Lander */
 import React from "react";
-import { FeaturedBadge, ProjectBadge } from "formidable-oss-badges";
+import { FeaturedBadge } from "formidable-oss-badges";
 import nightOwl from "prism-react-renderer/themes/nightOwl";
 
 import featureSvg from "./assets/feature.svg";
@@ -189,46 +189,6 @@ class Counter extends React.Component {
       label: "Documentation",
       href: "docs/",
     },
-  },
-  featuredOss: {
-    title: "More Open Source from Formidable",
-    list: [
-      {
-        badge: <FeaturedBadge name="victory" />,
-        href: "https://formidable.com/open-source/victory",
-        title: "Victory",
-        description:
-          "An ecosystem of modular data visualization components for React. Friendly and flexible.",
-      },
-      {
-        badge: <FeaturedBadge name="urql" />,
-        href: "https://formidable.com/open-source/urql",
-        title: "urql",
-        description:
-          "Universal React Query Library is a blazing-fast GraphQL client, exposed as a set of ReactJS components.",
-      },
-      {
-        badge: <FeaturedBadge name="spectacle" />,
-        href: "https://formidable.com/open-source/spectacle",
-        title: "Spectacle",
-        description:
-          "A React.js based library for creating sleek presentations using JSX syntax that gives you the ability to live demo your code.",
-      },
-      {
-        badge: (
-          <ProjectBadge
-            isHoverable={false}
-            color="#80EAC7"
-            abbreviation="Rp"
-            description="Runpkg"
-          />
-        ),
-        href: "https://formidable.com/open-source/runpkg",
-        title: "Runpkg",
-        description:
-          "The online package explorer. Runpkg turns any npm package into an interactive and informative browsing experience.",
-      },
-    ],
   },
 };
 

--- a/src/components/DocsPageTemplate.jsx
+++ b/src/components/DocsPageTemplate.jsx
@@ -15,16 +15,13 @@ const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-left: 24px;
   width: 100%;
-
-  ${(props) => props.theme.media.desktop`
-    padding-left: ${({ theme }) => theme.layout.sidebarWidth};
-  `}
 `;
 
 const DocsPageContainer = styled.div`
   display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   height: 100vh;
 `;
 
@@ -37,6 +34,14 @@ const DocContainer = styled.div`
   ${(props) => props.theme.media.desktop`
     padding: ${({ theme }) => theme.spacing(7.5)};
     margin-top: ${({ theme }) => theme.layout.headerHeight};
+  `}
+`;
+
+const StyledContent = styled.div`
+  margin-left: 24px;
+  z-index: 1;
+  ${(props) => props.theme.media.desktop`
+    margin-left: ${({ theme }) => theme.layout.sidebarWidth};
   `}
 `;
 
@@ -65,25 +70,27 @@ function DocsPageTemplate({ projectName, doc, toc, pages }) {
   return (
     <Wrapper className="Page-content">
       <DocsPageContainer>
-        <div ref={ref}>
-          <Sidebar
-            navLinks={pages}
-            projectName={projectName}
-            sidebarOpen={sidebarOpen}
-            onCloseClick={() => setSidebarOpen(false)}
-          />
-        </div>
         <ContentContainer>
-          <Header
-            title={projectName}
-            sidebarOpen={sidebarOpen}
-            onMenuClick={() => setSidebarOpen(true)}
-          />
-          <DocContainer sidebarOpen={sidebarOpen}>
-            <Doc doc={doc} toc={toc} />
-          </DocContainer>
-          <Footer />
+          <div ref={ref}>
+            <Sidebar
+              navLinks={pages}
+              projectName={projectName}
+              sidebarOpen={sidebarOpen}
+              onCloseClick={() => setSidebarOpen(false)}
+            />
+          </div>
+          <StyledContent>
+            <Header
+              title={projectName}
+              sidebarOpen={sidebarOpen}
+              onMenuClick={() => setSidebarOpen(true)}
+            />
+            <DocContainer sidebarOpen={sidebarOpen}>
+              <Doc doc={doc} toc={toc} />
+            </DocContainer>
+          </StyledContent>
         </ContentContainer>
+        <Footer sidebar />
       </DocsPageContainer>
     </Wrapper>
   );

--- a/src/components/FeaturedOSS.jsx
+++ b/src/components/FeaturedOSS.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-
+import { FeaturedBadge, ProjectBadge } from "formidable-oss-badges";
 import Button from "./Button";
 import Grid from "./Grid";
 import Section from "./Section";
@@ -87,47 +87,82 @@ const ButtonWrapper = styled.div`
     text-align: center;
   `};
 `;
+const featuredOss = [
+  {
+    badge: <FeaturedBadge name="victory" />,
+    href: "https://formidable.com/open-source/victory",
+    title: "Victory",
+    description:
+      "An ecosystem of modular data visualization components for React. Friendly and flexible.",
+  },
+  {
+    badge: <FeaturedBadge name="urql" />,
+    href: "https://formidable.com/open-source/urql",
+    title: "urql",
+    description:
+      "Universal React Query Library is a blazing-fast GraphQL client, exposed as a set of ReactJS components.",
+  },
+  {
+    badge: <FeaturedBadge name="spectacle" />,
+    href: "https://formidable.com/open-source/spectacle",
+    title: "Spectacle",
+    description:
+      "A React.js based library for creating sleek presentations using JSX syntax that gives you the ability to live demo your code.",
+  },
+  {
+    badge: (
+      <ProjectBadge
+        isHoverable={false}
+        color="#80EAC7"
+        abbreviation="Rp"
+        description="Runpkg"
+      />
+    ),
+    href: "https://formidable.com/open-source/runpkg",
+    title: "Runpkg",
+    description:
+      "The online package explorer. Runpkg turns any npm package into an interactive and informative browsing experience.",
+  },
+];
 
-const FeaturedOSS = ({ title, list }) => {
-  return (
-    <Wrapper>
-      <Section.Title>{title}</Section.Title>
-      <StyledGrid>
-        {list.map((project, index) => {
-          return (
-            <ProjectLink
-              key={`project-${index}`}
-              href={project.href}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Project>
-                <BadgeWrapper>{project.badge}</BadgeWrapper>
-                <TextWrapper>
-                  <StyledTitle as="span">{project.title}</StyledTitle>
-                  {project.description ? (
-                    <Section.Text>{project.description}</Section.Text>
-                  ) : null}
-                </TextWrapper>
-              </Project>
-            </ProjectLink>
-          );
-        })}
-        <ButtonWrapper>
-          <Button
-            color="light"
-            as="a"
-            href="https://formidable.com/open-source/"
+const FeaturedOSS = () => (
+  <Wrapper>
+    <Section.Title>More Open Source from Formidable</Section.Title>
+    <StyledGrid>
+      {featuredOss.map((project, index) => {
+        return (
+          <ProjectLink
+            key={`project-${index}`}
+            href={project.href}
             target="_blank"
             rel="noopener noreferrer"
           >
-            View All
-          </Button>
-        </ButtonWrapper>
-      </StyledGrid>
-    </Wrapper>
-  );
-};
+            <Project>
+              <BadgeWrapper>{project.badge}</BadgeWrapper>
+              <TextWrapper>
+                <StyledTitle as="span">{project.title}</StyledTitle>
+                {project.description ? (
+                  <Section.Text>{project.description}</Section.Text>
+                ) : null}
+              </TextWrapper>
+            </Project>
+          </ProjectLink>
+        );
+      })}
+      <ButtonWrapper>
+        <Button
+          color="light"
+          as="a"
+          href="https://formidable.com/open-source/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View All
+        </Button>
+      </ButtonWrapper>
+    </StyledGrid>
+  </Wrapper>
+);
 
 FeaturedOSS.propTypes = {
   /* Section title */

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-
+import PropTypes from "prop-types";
 import Grid from "./Grid";
 import Section from "./Section";
 import Text from "./Text";
@@ -13,10 +13,13 @@ const Wrapper = styled(Section).attrs({ padding: 10 })`
   color: ${(props) => props.theme.colors.white};
   text-align: left;
   width: 100%;
-
+  display: flex;
   ${(props) => props.theme.media.desktop`
-    width: calc(100vw - ${({ theme }) => theme.layout.sidebarWidth});
+    width: ${({ sidebar, theme }) =>
+      sidebar ? `calc(100vw - ${theme.layout.sidebarWidth})` : "100%"};
     height: ${(props) => props.theme.layout.footerHeight};
+    margin-left: ${({ theme, sidebar }) =>
+      sidebar ? theme.layout.sidebarWidth : "0"};
   `}
 
   ${linkStyles({ color: "white" })};
@@ -57,10 +60,10 @@ const StyledText = styled(Text)`
   max-width: 60ch;
 `;
 
-const Footer = () => {
+const Footer = ({ sidebar = false }) => {
   /* Let us take care of this for you */
   return (
-    <Wrapper>
+    <Wrapper sidebar={sidebar}>
       <StyledGrid>
         <LinksWrapper>
           <a
@@ -109,6 +112,10 @@ const Footer = () => {
       </StyledGrid>
     </Wrapper>
   );
+};
+
+Footer.propTypes = {
+  sidebar: PropTypes.bool,
 };
 
 export default Footer;

--- a/src/components/IndexPageTemplate.jsx
+++ b/src/components/IndexPageTemplate.jsx
@@ -24,7 +24,7 @@ function IndexPageTemplate({ config }) {
       {hasPreview ? <Preview {...config.preview} /> : null}
       {hasCustomSection ? <CustomSection {...config.customSection} /> : null}
       <GetStarted {...config.getStarted} />
-      <FeaturedOSS {...config.featuredOss} />
+      <FeaturedOSS />
       <Footer />
     </Wrapper>
   );
@@ -37,7 +37,6 @@ IndexPageTemplate.propTypes = {
     preview: PropTypes.shape({ ...Preview.propTypes }),
     customSection: PropTypes.shape({ ...CustomSection.propTypes }),
     getStarted: GetStarted.propTypes.isRequired,
-    featuredOss: FeaturedOSS.propTypes.isRequired,
   }),
 };
 

--- a/src/components/docs/Header.jsx
+++ b/src/components/docs/Header.jsx
@@ -14,7 +14,7 @@ const HeaderContainer = styled.header`
   padding-right: ${({ theme }) => theme.spacing(10)};
   position: fixed;
   width: 100%;
-  z-index: ${({ sidebarOpen }) => (sidebarOpen ? "-1" : "2")};
+  z-index: ${({ sidebarOpen }) => sidebarOpen && "0"};
 
   ${(props) => props.theme.media.desktop`
     width: calc(100% - ${({ theme }) => theme.layout.sidebarWidth});
@@ -35,9 +35,12 @@ const Title = styled.h1`
   font-size: 1.6rem;
   text-transform: uppercase;
   letter-spacing: 3.72px;
+  a {
+    color: black;
+  }
 `;
 
-const FormidableLogoWrapper = styled.div`
+const FormidableLogoWrapper = styled.a`
   display: none;
 
   ${(props) => props.theme.media.tablet`
@@ -66,9 +69,16 @@ const Header = ({ title, sidebarOpen, onMenuClick }) => {
           <MenuButton onClick={onMenuClick}>
             <BurgerIcon />
           </MenuButton>
-          <Title>{title}</Title>
+          <Title>
+            <a href="/">{title}</a>
+          </Title>
         </LeftContainer>
-        <FormidableLogoWrapper>
+        <FormidableLogoWrapper
+          href="https://formidable.com"
+          title="Formidable"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <FormidableTextLogo />
         </FormidableLogoWrapper>
       </InnerContainer>

--- a/src/components/docs/Sidebar.jsx
+++ b/src/components/docs/Sidebar.jsx
@@ -10,6 +10,7 @@ const SidebarContainer = styled.aside`
   width: ${({ theme }) => theme.layout.sidebarWidth};
   min-height: 100%;
   position: fixed;
+  z-index: ${({ sidebarOpen }) => (sidebarOpen ? "2" : "0")};
 `;
 
 const LighterStripe = styled.div`
@@ -24,13 +25,11 @@ const LightStripe = styled.div`
 
 const SidebarContent = styled.div`
   display: ${({ sidebarOpen }) => (sidebarOpen ? "flex" : "none")};
-  z-index: ${({ sidebarOpen }) => (sidebarOpen ? "1" : "0")};
   flex-direction: column;
   align-items: center;
   padding: ${({ theme }) => theme.spacing(3)} 0;
   width: 100%;
   background: ${({ theme }) => theme.colors.darkerPrimary};
-
   ${(props) => props.theme.media.desktop`
     display: flex;
   `}
@@ -70,9 +69,8 @@ const CloseButton = styled.button`
 `;
 
 const Sidebar = ({ navLinks, projectName, sidebarOpen, onCloseClick }) => {
-  console.log(navLinks);
   return (
-    <SidebarContainer>
+    <SidebarContainer sidebarOpen={sidebarOpen}>
       <LighterStripe />
       <LightStripe />
       <SidebarContent sidebarOpen={sidebarOpen}>
@@ -83,7 +81,7 @@ const Sidebar = ({ navLinks, projectName, sidebarOpen, onCloseClick }) => {
         <List>
           {navLinks.map((page, i) => (
             <ListItem key={i}>
-              <ListItemLink to={"/docs/" + page.route}>
+              <ListItemLink onClick={onCloseClick} to={"/docs/" + page.route}>
                 {page.name}
               </ListItemLink>
             </ListItem>


### PR DESCRIPTION
This PR makes a few small refactors, including:
- Making `featured-oss` inherent to the package (instead of user driven). It does not, however, dynamically pull the four most popular OSS projects in, though [we do have a ticket for that](https://trello.com/c/02ndwees).
- Styling updates to the `DocsPageTemplate.jsx` which I think are a little more intuitive than our previous setup
- Fixing the [issue with Footer styling](https://trello.com/c/hDRT5dmv)
- Adding links to the `Formidable` logo & Project logo in the header
- Closing the sidebar when a user selects a route